### PR TITLE
Quick: Frontera CMS: Fix old URLs to archive fonts

### DIFF
--- a/frontera-cms/static/frontera-cms/css/archive/main.frontera.css
+++ b/frontera-cms/static/frontera-cms/css/archive/main.frontera.css
@@ -7,27 +7,27 @@ NOTE: Relevant styles for Pre-2020 `frontera.scss`
 
 @font-face {
     font-family: BentonSansBold;
-    src: url("/static/site_cms/fonts/archive/BentonSans-Bold.otf");
+    src: url("/static/frontera-cms/fonts/archive/BentonSans-Bold.otf");
 }
 
 @font-face {
     font-family: BentonSansMedium;
-    src: url("/static/site_cms/fonts/archive/BentonSans-Medium.otf");
+    src: url("/static/frontera-cms/fonts/archive/BentonSans-Medium.otf");
 }
 
 @font-face {
     font-family: BentonSansItalic;
-    src: url("/static/site_cms/fonts/archive/BentonSans-MediumItalic.otf");
+    src: url("/static/frontera-cms/fonts/archive/BentonSans-MediumItalic.otf");
 }
 
 /* … */
 
 @font-face {
 	font-family: 'icon-worksregular';
-	src: url('/static/site_cms/fonts/archive/icon-works-webfont.eot');
-	src: url('/static/site_cms/fonts/archive/icon-works-webfont.eot?#iefix') format('embedded-opentype'),
-		url('/static/site_cms/fonts/archive/icon-works-webfont.woff') format('woff'),
-		url('/static/site_cms/fonts/archive/icon-works-webfont.svg#icon-worksregular') format('svg');
+	src: url('/static/frontera-cms/fonts/archive/icon-works-webfont.eot');
+	src: url('/static/frontera-cms/fonts/archive/icon-works-webfont.eot?#iefix') format('embedded-opentype'),
+		url('/static/frontera-cms/fonts/archive/icon-works-webfont.woff') format('woff'),
+		url('/static/frontera-cms/fonts/archive/icon-works-webfont.svg#icon-worksregular') format('svg');
 	font-weight: normal;
 	font-style: normal;
 }


### PR DESCRIPTION
# Goal

Update URLs to Frontera archive fonts (no longer in `site_cms`).