### PR TITLE
Quick: FP-893/FP-977: Support new templates

### DIFF
--- a/3dem-org/secrets.py
+++ b/3dem-org/secrets.py
@@ -18,7 +18,6 @@ _LDAP_ENABLED = True
 
 _CMS_TEMPLATES = (
     ('3dem-org/templates/fullwidth.html', 'Fullwidth'),
-    ('home_portal.html', 'Standard Portal Homepage'),
     ('guide.html', 'Guide'),
     ('guides/getting_started.html', 'Guide: Getting Started'),
     ('guides/data_transfer.html', 'Guide: Data Transfer'),

--- a/3dem-org/secrets.py
+++ b/3dem-org/secrets.py
@@ -17,7 +17,13 @@ _LDAP_ENABLED = True
 ########################
 
 _CMS_TEMPLATES = (
-    ('3dem-org/templates/fullwidth.html', 'Fullwidth')
+    ('3dem-org/templates/fullwidth.html', 'Fullwidth'),
+    ('home_portal.html', 'Standard Portal Homepage'),
+    ('guide.html', 'Guide'),
+    ('guides/getting_started.html', 'Guide: Getting Started'),
+    ('guides/data_transfer.html', 'Guide: Data Transfer'),
+    ('guides/data_transfer.globus.html', 'Guide: Globus Data Transfer'),
+    ('guides/portal_technology.html', 'Guide: Portal Technology Stack')
 )
 
 ########################

--- a/example-cms/secrets.py
+++ b/example-cms/secrets.py
@@ -18,7 +18,16 @@ _LDAP_ENABLED = False
 
 _CMS_TEMPLATES = (
     ('example-cms/templates/fullwidth.html', 'Fullwidth'),
-    ('fullwidth.html', 'DEPRECATED Fullwidth'),
+    # Support standard template for demo purposes
+    ('fullwidth.html', 'Standard Fullwidth'),
+
+    # Support Portal pages for demo purposes
+    ('home_portal.html', 'Standard Portal Homepage'),
+    ('guide.html', 'Guide'),
+    ('guides/getting_started.html', 'Guide: Getting Started'),
+    ('guides/data_transfer.html', 'Guide: Data Transfer'),
+    ('guides/data_transfer.globus.html', 'Guide: Globus Data Transfer'),
+    ('guides/portal_technology.html', 'Guide: Portal Technology Stack')
 )
 
 ########################

--- a/frontera-cms/secrets.py
+++ b/frontera-cms/secrets.py
@@ -16,6 +16,11 @@ _LDAP_ENABLED = True
 _CMS_TEMPLATES = (
     ('frontera-cms/templates/fullwidth.html', 'Fullwidth'),
     ('fullwidth.html', 'DEPRECATED Fullwidth'),
+    ('guide.html', 'Guide'),
+    ('guides/getting_started.html', 'Guide: Getting Started'),
+    ('guides/data_transfer.html', 'Guide: Data Transfer'),
+    ('guides/data_transfer.globus.html', 'Guide: Globus Data Transfer'),
+    ('guides/portal_technology.html', 'Guide: Portal Technology Stack')
 )
 
 ########################

--- a/neuronex-cms/secrets.py
+++ b/neuronex-cms/secrets.py
@@ -18,7 +18,12 @@ _LDAP_ENABLED = False
 
 _CMS_TEMPLATES = (
     ('neuronex-cms/templates/fullwidth.html', 'Fullwidth'),
-    ('fullwidth.html', 'DEPRECATED Fullwidth'),
+    ('home_portal.html', 'Standard Portal Homepage'),
+    ('guide.html', 'Guide'),
+    ('guides/getting_started.html', 'Guide: Getting Started'),
+    ('guides/data_transfer.html', 'Guide: Data Transfer'),
+    ('guides/data_transfer.globus.html', 'Guide: Globus Data Transfer'),
+    ('guides/portal_technology.html', 'Guide: Portal Technology Stack')
 )
 
 ########################

--- a/neuronex-cms/secrets.py
+++ b/neuronex-cms/secrets.py
@@ -18,7 +18,6 @@ _LDAP_ENABLED = False
 
 _CMS_TEMPLATES = (
     ('neuronex-cms/templates/fullwidth.html', 'Fullwidth'),
-    ('home_portal.html', 'Standard Portal Homepage'),
     ('guide.html', 'Guide'),
     ('guides/getting_started.html', 'Guide: Getting Started'),
     ('guides/data_transfer.html', 'Guide: Data Transfer'),

--- a/texascale-org/secrets.py
+++ b/texascale-org/secrets.py
@@ -8,8 +8,6 @@ import os
 
 # …
 _CMS_TEMPLATES = (
-    # ('fullwidth.html', 'Fullwidth'),
-    # ('sidebar_left.html', 'Sidebar Left'),
     ('texascale-org/templates/fullwidth.html', 'Fullwidth'),
     ('texascale-org/templates/category.html', 'Category'),
     ('texascale-org/templates/article.html', 'Article'),


### PR DESCRIPTION
# Overview

- Enable new guide templates for portal CMS's.
- Enable new templates for `example-cms` (for demo purposes).
- Disable outdated Texascale templates.