### PR TITLE
Quick: Fix neuronex setting

### DIFF
--- a/neuronex-cms/secrets.py
+++ b/neuronex-cms/secrets.py
@@ -10,7 +10,7 @@
 # DJANGO SETTINGS
 ########################
 
-_LDAP_ENABLED = False
+_LDAP_ENABLED = True
 
 ########################
 # DJANGO CMS SETTINGS


### PR DESCRIPTION
## Overview

Fix boolean value for `neuronex-cms` setting.

## Notes

This is a noop, because the change is to a static file that is currently _only_ for manual reference. And the person referencing the file — @rstijerina — knows the correct value.