### PR TITLE
Quick: Add home template to neuronex-cms secrets

### DIFF
--- a/neuronex-cms/secrets.py
+++ b/neuronex-cms/secrets.py
@@ -18,6 +18,7 @@ _LDAP_ENABLED = True
 
 _CMS_TEMPLATES = (
     ('neuronex-cms/templates/fullwidth.html', 'Fullwidth'),
+    ('home_portal.html', 'Standard Portal Homepage'),
     ('guide.html', 'Guide'),
     ('guides/getting_started.html', 'Guide: Getting Started'),
     ('guides/data_transfer.html', 'Guide: Data Transfer'),


### PR DESCRIPTION
# Overview

Add missing entry for "Standard Portal Homepage" to `neronex-cms`'s `secrets.py` "manual patch file".