### PR TITLE
Quick: Remove body bkgd warn color for new sites

### DIFF
--- a/example-cms/static/example-cms/css/src/_imports/generic/roots.css
+++ b/example-cms/static/example-cms/css/src/_imports/generic/roots.css
@@ -1,5 +1,6 @@
-/* GENEERICS: Roots */
+/* GENERICS: Roots */
 
 body {
+  /* FAQ: This color change merely illustrates that custom styles are working */
   background-color: yellow;
 }

--- a/neuronex-cms/static/neuronex-cms/css/src/_imports/generic/roots.css
+++ b/neuronex-cms/static/neuronex-cms/css/src/_imports/generic/roots.css
@@ -1,5 +1,6 @@
-/* GENEERICS: Roots */
+/* GENERICS: Roots */
 
 body {
-  background-color: yellow;
+  /* FAQ: This color change merely illustrates that custom styles are working */
+  /* background-color: yellow; */
 }

--- a/protx-cms/static/protx-cms/css/src/_imports/generic/roots.css
+++ b/protx-cms/static/protx-cms/css/src/_imports/generic/roots.css
@@ -1,5 +1,6 @@
-/* GENEERICS: Roots */
+/* GENERICS: Roots */
 
 body {
-  background-color: yellow;
+  /* FAQ: This color change merely illustrates that custom styles are working */
+  /* background-color: yellow; */
 }


### PR DESCRIPTION
# Overview

Remove warning background color from the newest sites' starter CSS.

> Also, fix typos and add comment about purpose of this awful background color.

# Testing

0. Follow [Test New CMS Site](https://github.com/TACC/cms-site-resources/wiki/Test-New-CMS-Site) instructions.
1. (In Step 2 of [Test New CMS Site](https://github.com/TACC/cms-site-resources/wiki/Test-New-CMS-Site)) Set CMS to run as `neuronex-cms` or `protx-cms`.
2. Load a page that uses `neuronex-cms` or `protx-cms`'s `fullwidth.html` template.
3. Ensure background is white.\*

_\* If background is not white, and you are testing with local image on local standalone CMS, be sure you run `npm run build`._

## Resources

remote docker images:
- `taccwma/neuronex-cms:0dd0aa4`