### PR TITLE
Quick: Add empty Core cms directory

### DIFF
--- a/core-cms/README.md
+++ b/core-cms/README.md
@@ -1,0 +1,5 @@
+# Intentionally Empty
+
+This directory is intentionally empty. The Core CMS has zero custom assets.
+
+To start a new project, clone the `example-cms` directory.


### PR DESCRIPTION
# Dependencies

- [ ] https://github.com/TACC/Core-CMS/pull/176

# Overview

Support `core-cms` as `CUSTOM_ASSET_DIR` in image build configuration (even if Core has no assets).

> This will allow us to combine `dockerhub_repo` and `CUSTOM_ASSET_DIR` into one parameter.

# Related Tickets

- [FP-981](https://jira.tacc.utexas.edu/browse/FP-981)

# Testing

0. Build new docker image using `core-cms` for both.
    - You may use `taccwma/core-cms:7d3351b`.
0. Follow [Test New CMS Site](https://github.com/TACC/cms-site-resources/wiki/Test-New-CMS-Site) instructions.
    - If testing on a local standalone CMS, be sure you're on the matching branch for [`Core-CMS`](https://github.com/TACC/Core-CMS).
1. (In Step 2 of [Test New CMS Site](https://github.com/TACC/cms-site-resources/wiki/Test-New-CMS-Site)) Set CMS to run as `core-cms`.
2. Load a page that uses the Core `fullwidth.html` template.
3. Ensure background is white.\*†

_\* If background is not white, and you are testing with local image on local standalone CMS, be sure you run `npm run build`._
_† Because `example-cms`, previous "Core" build has yellow background._

## Resources

- remote docker image: `taccwma/core-cms:7d3351b`